### PR TITLE
Modification to prepend html5 doctype

### DIFF
--- a/src/main/java/net/itarray/automotion/internal/HtmlReportBuilder.java
+++ b/src/main/java/net/itarray/automotion/internal/HtmlReportBuilder.java
@@ -58,6 +58,7 @@ public class HtmlReportBuilder {
 
     private Html buildHtml() throws IOException, ParseException {
         return new Html(null, new Style("background-color: rgb(255,250,250)")) {{
+            super.setPrependDocType(true);
             new Head(this) {{
                 new TitleTag(this) {{
                     new NoTag(this, "Automotion report");


### PR DESCRIPTION
As per w3 standard, for an html page there must be a doctype declared in the first line. This modification declares <!DOCTYPE> which represents HTML5 compliant markup.